### PR TITLE
feat!: Rework `SubsetOf` and `SetEq` impls

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -4,7 +4,7 @@ use quote::quote;
 use syn::{Data, DeriveInput, parse_quote};
 
 #[proc_macro_derive(Set)]
-pub fn set_derive_method(input: TokenStream) -> TokenStream {
+pub fn set_derive(input: TokenStream) -> TokenStream {
     let input = proc_macro2::TokenStream::from(input);
 
     let input: DeriveInput = syn::parse2(input).unwrap();
@@ -94,7 +94,7 @@ pub fn set_derive_method(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(UnionAssign)]
-pub fn union_in_place_derive_method(input: TokenStream) -> TokenStream {
+pub fn union_assign_derive(input: TokenStream) -> TokenStream {
     let input = proc_macro2::TokenStream::from(input);
 
     let input: DeriveInput = syn::parse2(input).unwrap();
@@ -146,7 +146,7 @@ pub fn union_in_place_derive_method(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(DifferenceAssign)]
-pub fn difference_in_place_derive_method(input: TokenStream) -> TokenStream {
+pub fn difference_assign_derive(input: TokenStream) -> TokenStream {
     let input = proc_macro2::TokenStream::from(input);
 
     let input: DeriveInput = syn::parse2(input).unwrap();
@@ -198,7 +198,7 @@ pub fn difference_in_place_derive_method(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(IntersectionAssign)]
-pub fn intersection_in_place_derive_method(input: TokenStream) -> TokenStream {
+pub fn intersection_assign_derive(input: TokenStream) -> TokenStream {
     let input = proc_macro2::TokenStream::from(input);
 
     let input: DeriveInput = syn::parse2(input).unwrap();
@@ -250,7 +250,7 @@ pub fn intersection_in_place_derive_method(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(DisjunctiveUnionAssign)]
-pub fn disjunctive_union_in_place_derive_method(input: TokenStream) -> TokenStream {
+pub fn disjunctive_union_assign_derive(input: TokenStream) -> TokenStream {
     let input = proc_macro2::TokenStream::from(input);
 
     let input: DeriveInput = syn::parse2(input).unwrap();
@@ -294,6 +294,110 @@ pub fn disjunctive_union_in_place_derive_method(input: TokenStream) -> TokenStre
     quote! {
         impl #crate_name::operations::DisjunctiveUnionAssign<&#struct_name> for #struct_name {
             fn disjunctive_union_assign(&mut self, rhs: &#struct_name) {
+                #function_body
+            }
+        }
+    }
+    .into()
+}
+
+#[proc_macro_derive(SetEq)]
+pub fn set_eq_derive(input: TokenStream) -> TokenStream {
+    let input = proc_macro2::TokenStream::from(input);
+
+    let input: DeriveInput = syn::parse2(input).unwrap();
+
+    let crate_name: syn::Path = parse_quote!(::finit);
+    let struct_name = &input.ident;
+
+    let Data::Struct(struct_data) = &input.data else {
+        unimplemented!("Currently, there is only support for structs.");
+    };
+
+    let function_body: Vec<proc_macro2::TokenStream> = match &struct_data.fields {
+        syn::Fields::Named(fields) => fields
+            .named
+            .iter()
+            .map(|field| {
+                let field_name = field.ident.as_ref().expect("Struct is named.");
+                quote! {
+                    #crate_name::comparisons::SetEq::set_eq(&self.#field_name, &rhs.#field_name)
+                }
+            })
+            .collect(),
+        syn::Fields::Unnamed(fields) => fields
+            .unnamed
+            .iter()
+            .enumerate()
+            .map(|(i, _field)| {
+                quote! {
+                    #crate_name::comparisons::SetEq::set_eq(&self.#i, &rhs.#i)
+                }
+            })
+            .collect(),
+        syn::Fields::Unit => panic!("Unit structs can't be a set."),
+    };
+
+    let function_body = function_body
+        .into_iter()
+        .reduce(|acc, value| quote! { #acc && #value})
+        .expect("No unit structs means there must be atleast 1 field.");
+
+    quote! {
+        impl #crate_name::comparisons::SetEq<#struct_name> for #struct_name {
+            fn set_eq(&self, rhs: &#struct_name) -> bool {
+                #function_body
+            }
+        }
+    }
+    .into()
+}
+
+#[proc_macro_derive(SubsetOf)]
+pub fn subset_of_derive(input: TokenStream) -> TokenStream {
+    let input = proc_macro2::TokenStream::from(input);
+
+    let input: DeriveInput = syn::parse2(input).unwrap();
+
+    let crate_name: syn::Path = parse_quote!(::finit);
+    let struct_name = &input.ident;
+
+    let Data::Struct(struct_data) = &input.data else {
+        unimplemented!("Currently, there is only support for structs.");
+    };
+
+    let function_body: Vec<proc_macro2::TokenStream> = match &struct_data.fields {
+        syn::Fields::Named(fields) => fields
+            .named
+            .iter()
+            .map(|field| {
+                let field_name = field.ident.as_ref().expect("Struct is named.");
+                quote! {
+                    #crate_name::comparisons::SubsetOf::subset_of(&self.#field_name, &rhs.#field_name)
+                }
+            })
+            .collect(),
+        syn::Fields::Unnamed(fields) => fields
+            .unnamed
+            .iter()
+            .enumerate()
+            .map(|(i, _field)| {
+                quote! {
+                    #crate_name::comparisons::SubsetOf::subset_of(&self.#i, &rhs.#i)
+                }
+            })
+            .collect(),
+        syn::Fields::Unit => panic!("Unit structs can't be a set."),
+    };
+
+    let function_body = function_body
+        .into_iter()
+        .reduce(|acc, value| quote! { #acc && #value})
+        .expect("No unit structs means there must be atleast 1 field.");
+
+    quote! {
+        impl #crate_name::comparisons::SubsetOf<#struct_name> for #struct_name {
+            fn subset_of(&self, rhs: &#struct_name) -> bool {
                 #function_body
             }
         }

--- a/examples/clans.rs
+++ b/examples/clans.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
-use finit::comparisons::SubsetOf;
+use finit::comparisons::{SubsetOf, SetEq};
 use finit::operations::{
     DifferenceAssign, DisjunctiveUnionAssign, IntersectionAssign, UnionAssign,
 };
-use finit::{Set, set_eq_partial_eq_impl};
+use finit::{Set};
 use maplit::hashmap;
 
 #[derive(
@@ -15,13 +15,14 @@ use maplit::hashmap;
     DifferenceAssign,
     IntersectionAssign,
     DisjunctiveUnionAssign,
+    SetEq,
+    SubsetOf,
     PartialEq,
 )]
 pub struct ThemingPerms {
     can_have_dark_mode: bool,
     allowed_themes: HashMap<String, bool>,
 }
-set_eq_partial_eq_impl!(ThemingPerms);
 
 #[derive(
     Debug,
@@ -31,6 +32,8 @@ set_eq_partial_eq_impl!(ThemingPerms);
     DifferenceAssign,
     IntersectionAssign,
     DisjunctiveUnionAssign,
+    SetEq,
+    SubsetOf,
     PartialEq,
 )]
 pub struct ClanPerms {
@@ -38,7 +41,6 @@ pub struct ClanPerms {
     ban: bool,
     owner: bool,
 }
-set_eq_partial_eq_impl!(ClanPerms);
 
 #[derive(
     Debug,
@@ -48,6 +50,8 @@ set_eq_partial_eq_impl!(ClanPerms);
     DifferenceAssign,
     IntersectionAssign,
     DisjunctiveUnionAssign,
+    SetEq,
+    SubsetOf,
     PartialEq,
 )]
 pub struct UserPerms {
@@ -55,7 +59,6 @@ pub struct UserPerms {
     clans: HashMap<String, ClanPerms>,
     account_access: bool,
 }
-set_eq_partial_eq_impl!(UserPerms);
 
 impl UserPerms {
     fn is_owner_of_clan(&self, clan_name: String) -> bool {

--- a/src/collections/wildcard_btreemap.rs
+++ b/src/collections/wildcard_btreemap.rs
@@ -1,4 +1,5 @@
 use crate::Set;
+use crate::comparisons::{SetEq, SubsetOf};
 use crate::operations::identity::{
     disjunctive_union_using_difference_and_union, intersection_using_double_difference,
 };
@@ -424,6 +425,89 @@ where
 {
     fn disjunctive_union_assign(&mut self, rhs: WildcardBTreeMap<Key, OtherValue>) {
         *self = disjunctive_union_using_difference_and_union(self.clone(), rhs);
+    }
+}
+
+impl<Key: Ord + Eq + Clone, Value: Set + SetEq<OtherValue>, OtherValue: Set>
+    SetEq<WildcardBTreeMap<Key, OtherValue>> for WildcardBTreeMap<Key, Value>
+{
+    fn set_eq(&self, rhs: &WildcardBTreeMap<Key, OtherValue>) -> bool {
+        self.wildcard_value.set_eq(rhs.wildcard_value.as_ref())
+            && self.wildcard_exceptions.set_eq(&rhs.wildcard_exceptions)
+            && self.rest_list.set_eq(&rhs.rest_list)
+    }
+}
+
+impl<Key: Ord + Eq + Clone, Value: Set + SetEq<OtherValue>, OtherValue: Set>
+    SetEq<BTreeMap<Key, OtherValue>> for WildcardBTreeMap<Key, Value>
+{
+    fn set_eq(&self, rhs: &BTreeMap<Key, OtherValue>) -> bool {
+        self.wildcard_value.is_empty() && self.rest_list.set_eq(rhs)
+    }
+}
+
+impl<Key: Ord + Eq + Clone, Value: Set + SubsetOf<OtherValue>, OtherValue: Set>
+    SubsetOf<WildcardBTreeMap<Key, OtherValue>> for WildcardBTreeMap<Key, Value>
+where
+    for<'a> Value: DifferenceAssign<&'a Value>
+        + DifferenceAssign<&'a OtherValue>
+        + UnionAssign<&'a Value>
+        + IntersectionAssign<&'a OtherValue>
+        + Clone,
+{
+    fn subset_of(&self, rhs: &WildcardBTreeMap<Key, OtherValue>) -> bool {
+        // The wildcard itself must be a subset
+        if !self.wildcard_value.subset_of(rhs.wildcard_value.as_ref()) {
+            return false;
+        }
+
+        let mut checked_keys = std::collections::BTreeSet::new();
+
+        for key in rhs.wildcard_exceptions.keys().chain(self.rest_list.keys()) {
+            if checked_keys.contains(key) {
+                continue;
+            }
+            checked_keys.insert(key);
+
+            let mut a = self.wildcard_value.deref().clone();
+            if let Some(exc) = self.wildcard_exceptions.get(key) {
+                a.difference_assign(exc);
+            }
+            if let Some(rest) = self.rest_list.get(key) {
+                a.union_assign(rest);
+            }
+
+            if let Some(rhs_rest) = rhs.rest_list.get(key) {
+                a.difference_assign(rhs_rest);
+            }
+
+            let mut a_minus_wb = a.clone();
+            a_minus_wb.difference_assign(rhs.wildcard_value.as_ref());
+            if !a_minus_wb.is_empty() {
+                return false;
+            }
+
+            if let Some(rhs_exc) = rhs.wildcard_exceptions.get(key) {
+                a.intersection_assign(rhs_exc);
+                if !a.is_empty() {
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+}
+
+impl<Key: Ord + Eq + Clone, Value: Set + SubsetOf<OtherValue>, OtherValue: Set>
+    SubsetOf<BTreeMap<Key, OtherValue>> for WildcardBTreeMap<Key, Value>
+{
+    fn subset_of(&self, rhs: &BTreeMap<Key, OtherValue>) -> bool {
+        if !self.wildcard_value.is_empty() {
+            return false;
+        }
+
+        self.rest_list.subset_of(rhs)
     }
 }
 

--- a/src/collections/wildcard_hashmap.rs
+++ b/src/collections/wildcard_hashmap.rs
@@ -1,4 +1,5 @@
 use crate::Set;
+use crate::comparisons::{SetEq, SubsetOf};
 use crate::operations::identity::{
     disjunctive_union_using_difference_and_union, intersection_using_double_difference,
 };
@@ -423,6 +424,89 @@ where
 {
     fn disjunctive_union_assign(&mut self, rhs: WildcardHashMap<Key, OtherValue>) {
         *self = disjunctive_union_using_difference_and_union(self.clone(), rhs);
+    }
+}
+
+impl<Key: Hash + Eq + Clone, Value: Set + SetEq<OtherValue>, OtherValue: Set>
+    SetEq<WildcardHashMap<Key, OtherValue>> for WildcardHashMap<Key, Value>
+{
+    fn set_eq(&self, rhs: &WildcardHashMap<Key, OtherValue>) -> bool {
+        self.wildcard_value.set_eq(rhs.wildcard_value.as_ref())
+            && self.wildcard_exceptions.set_eq(&rhs.wildcard_exceptions)
+            && self.rest_list.set_eq(&rhs.rest_list)
+    }
+}
+
+impl<Key: Hash + Eq + Clone, Value: Set + SetEq<OtherValue>, OtherValue: Set>
+    SetEq<HashMap<Key, OtherValue>> for WildcardHashMap<Key, Value>
+{
+    fn set_eq(&self, rhs: &HashMap<Key, OtherValue>) -> bool {
+        self.wildcard_value.is_empty() && self.rest_list.set_eq(rhs)
+    }
+}
+
+impl<Key: Hash + Eq + Clone, Value: Set + SubsetOf<OtherValue>, OtherValue: Set>
+    SubsetOf<WildcardHashMap<Key, OtherValue>> for WildcardHashMap<Key, Value>
+where
+    for<'a> Value: DifferenceAssign<&'a Value>
+        + DifferenceAssign<&'a OtherValue>
+        + UnionAssign<&'a Value>
+        + IntersectionAssign<&'a OtherValue>
+        + Clone,
+{
+    fn subset_of(&self, rhs: &WildcardHashMap<Key, OtherValue>) -> bool {
+        // The wildcard itself must be a subset
+        if !self.wildcard_value.subset_of(rhs.wildcard_value.as_ref()) {
+            return false;
+        }
+
+        let mut checked_keys = std::collections::HashSet::new();
+
+        for key in rhs.wildcard_exceptions.keys().chain(self.rest_list.keys()) {
+            if checked_keys.contains(key) {
+                continue;
+            }
+            checked_keys.insert(key);
+
+            let mut a = self.wildcard_value.deref().clone();
+            if let Some(exc) = self.wildcard_exceptions.get(key) {
+                a.difference_assign(exc);
+            }
+            if let Some(rest) = self.rest_list.get(key) {
+                a.union_assign(rest);
+            }
+
+            if let Some(rhs_rest) = rhs.rest_list.get(key) {
+                a.difference_assign(rhs_rest);
+            }
+
+            let mut a_minus_wb = a.clone();
+            a_minus_wb.difference_assign(rhs.wildcard_value.as_ref());
+            if !a_minus_wb.is_empty() {
+                return false;
+            }
+
+            if let Some(rhs_exc) = rhs.wildcard_exceptions.get(key) {
+                a.intersection_assign(rhs_exc);
+                if !a.is_empty() {
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+}
+
+impl<Key: Hash + Eq + Clone, Value: Set + SubsetOf<OtherValue>, OtherValue: Set>
+    SubsetOf<HashMap<Key, OtherValue>> for WildcardHashMap<Key, Value>
+{
+    fn subset_of(&self, rhs: &HashMap<Key, OtherValue>) -> bool {
+        if !self.wildcard_value.is_empty() {
+            return false;
+        }
+
+        self.rest_list.subset_of(rhs)
     }
 }
 
@@ -882,5 +966,99 @@ mod tests {
     {
         list1.disjunctive_union_assign(list2);
         assert_eq!(list1, result);
+    }
+
+    #[rstest]
+    // Subset tests
+    #[case(WildcardHashMap::<i32, bool> {
+        wildcard_value: Box::new(false),
+        wildcard_exceptions: hashmap! {},
+        rest_list: hashmap! {},
+    }, WildcardHashMap {
+        wildcard_value: Box::new(false),
+        wildcard_exceptions: hashmap! {},
+        rest_list: hashmap! {},
+    }, true)]
+    #[case(WildcardHashMap::<i32, bool> {
+        wildcard_value: Box::new(true),
+        wildcard_exceptions: hashmap! {},
+        rest_list: hashmap! {},
+    }, WildcardHashMap {
+        wildcard_value: Box::new(true),
+        wildcard_exceptions: hashmap! {},
+        rest_list: hashmap! {},
+    }, true)]
+    // subset is smaller wildcard
+    #[case(WildcardHashMap::<i32, bool> {
+        wildcard_value: Box::new(false),
+        wildcard_exceptions: hashmap! {},
+        rest_list: hashmap! {},
+    }, WildcardHashMap {
+        wildcard_value: Box::new(true),
+        wildcard_exceptions: hashmap! {},
+        rest_list: hashmap! {},
+    }, true)]
+    // subset has more exceptions
+    #[case(WildcardHashMap::<i32, bool> {
+        wildcard_value: Box::new(true),
+        wildcard_exceptions: hashmap! {
+            1 => true,
+        },
+        rest_list: hashmap! {},
+    }, WildcardHashMap {
+        wildcard_value: Box::new(true),
+        wildcard_exceptions: hashmap! {},
+        rest_list: hashmap! {},
+    }, true)]
+    // superset has more exceptions -> false
+    #[case(WildcardHashMap::<i32, bool> {
+        wildcard_value: Box::new(true),
+        wildcard_exceptions: hashmap! {},
+        rest_list: hashmap! {},
+    }, WildcardHashMap {
+        wildcard_value: Box::new(true),
+        wildcard_exceptions: hashmap! {
+            1 => true,
+        },
+        rest_list: hashmap! {},
+    }, false)]
+    // subset rest_list goes into wildcard
+    #[case(WildcardHashMap::<i32, bool> {
+        wildcard_value: Box::new(false),
+        wildcard_exceptions: hashmap! {},
+        rest_list: hashmap! {
+            1 => true,
+        },
+    }, WildcardHashMap {
+        wildcard_value: Box::new(true),
+        wildcard_exceptions: hashmap! {},
+        rest_list: hashmap! {},
+    }, true)]
+    // subset rest_list goes into exception -> false
+    #[case(WildcardHashMap::<i32, bool> {
+        wildcard_value: Box::new(false),
+        wildcard_exceptions: hashmap! {},
+        rest_list: hashmap! {
+            1 => true,
+        },
+    }, WildcardHashMap {
+        wildcard_value: Box::new(true),
+        wildcard_exceptions: hashmap! {
+            1 => true,
+        },
+        rest_list: hashmap! {},
+    }, false)]
+    fn subset_of_list_tests<I1, I2>(#[case] list1: I1, #[case] list2: I2, #[case] expected: bool)
+    where
+        I1: SubsetOf<I2> + Debug,
+        I2: Debug,
+    {
+        assert_eq!(
+            list1.subset_of(&list2),
+            expected,
+            "{:?} subset_of {:?}",
+            list1,
+            list2
+        );
     }
 }

--- a/src/comparisons.rs
+++ b/src/comparisons.rs
@@ -1,22 +1,41 @@
 //! This module contains traits for comparing sets, such as checking if two sets are equal, if one set is a subset of another, etc.
 use crate::operations::*;
 
+#[cfg(feature = "derive")]
+pub use finit_derive::{SetEq, SubsetOf};
+
 /// [`SetEq`] (≡) will check if Self and Rhs are equal as sets, ignoring any non-set properties.
 /// This is not the same as PartialEq, since two sets can be equal even if they are different types, as long as they contain the same elements.
 pub trait SetEq<Rhs = Self> {
     fn set_eq(&self, rhs: &Rhs) -> bool;
 }
 
+impl<T: SetEq<Rhs>, Rhs> SetEq<Rhs> for &T {
+    fn set_eq(&self, rhs: &Rhs) -> bool {
+        T::set_eq(*self, rhs)
+    }
+}
+
 /// A helper macro to implement [`SetEq`] for types that also implement [`PartialEq`], since in many cases they will be the same.
 #[macro_export]
 macro_rules! set_eq_partial_eq_impl {
+    (($($wh:tt)+): $($t:tt)+) => {
+        impl<$($wh)*> $crate::comparisons::SetEq for $($t)* {
+            fn set_eq(&self, rhs: &Self) -> bool {
+                PartialEq::eq(self, rhs)
+            }
+        }
+    };
+    ($t:ty) => {
+        impl $crate::comparisons::SetEq for $t {
+            fn set_eq(&self, rhs: &Self) -> bool {
+                PartialEq::eq(self, rhs)
+            }
+        }
+    };
     ($($t:ty),*) => {
         $(
-            impl $crate::comparisons::SetEq for $t {
-                fn set_eq(&self, rhs: &Self) -> bool {
-                    PartialEq::eq(self, rhs)
-                }
-            }
+            set_eq_partial_eq_impl!($t);
         )*
     };
 }
@@ -26,13 +45,26 @@ pub trait SubsetOf<Rhs = Self> {
     fn subset_of(&self, rhs: &Rhs) -> bool;
 }
 
-impl<T: Clone + SetEq, Rhs> SubsetOf<Rhs> for T
-where
-    for<'a> T: IntersectionAssign<&'a Rhs>,
-{
+impl<T: SubsetOf<Rhs>, Rhs> SubsetOf<Rhs> for &T {
     fn subset_of(&self, rhs: &Rhs) -> bool {
-        identity::subset_using_intersection_eq(self, rhs)
+        T::subset_of(*self, rhs)
     }
+}
+
+#[macro_export]
+macro_rules! subset_of_intersection_identity_impl {
+    ($t:ty) => {
+        impl $crate::comparisons::SubsetOf for $t {
+            fn subset_of(&self, rhs: &Self) -> bool {
+                $crate::comparisons::identity::subset_using_intersection_eq(self, rhs)
+            }
+        }
+    };
+    ($($t:ty),*) => {
+        $(
+            subset_of_intersection_identity_impl!($t);
+        )*
+    };
 }
 
 /// [`StrictSubsetOf`] (⊂) will check if Rhs contains Self, but they cannot be equal. This is the opposite of [`StrictSupersetOf`], so A ⊂ B if and only if B ⊃ A.

--- a/src/impls/array.rs
+++ b/src/impls/array.rs
@@ -3,6 +3,7 @@ use crate::operations::{
     Difference, DifferenceAssign, DisjunctiveUnion, DisjunctiveUnionAssign, Intersection,
     IntersectionAssign, Union, UnionAssign,
 };
+use crate::comparisons::{SetEq, SubsetOf};
 
 impl<const N: usize, Value: Set<Empty = Value>> Set for [Value; N] {
     type Empty = Self;
@@ -219,6 +220,22 @@ where
         self.disjunctive_union_assign(rhs);
 
         self
+    }
+}
+
+impl<const N: usize, Value: SetEq<OtherValue>, OtherValue> SetEq<[OtherValue; N]>
+    for [Value; N]
+{
+    fn set_eq(&self, rhs: &[OtherValue; N]) -> bool {
+        self.iter().zip(rhs.iter()).all(|(self_v, rhs_v)| self_v.set_eq(rhs_v))
+    }
+}
+
+impl<const N: usize, Value: SubsetOf<OtherValue>, OtherValue> SubsetOf<[OtherValue; N]>
+    for [Value; N]
+{
+    fn subset_of(&self, rhs: &[OtherValue; N]) -> bool {
+        self.iter().zip(rhs.iter()).all(|(self_v, rhs_v)| self_v.subset_of(rhs_v))
     }
 }
 

--- a/src/impls/bool.rs
+++ b/src/impls/bool.rs
@@ -153,6 +153,10 @@ impl DisjunctiveUnionAssign<&bool> for bool {
     }
 }
 
+crate::set_eq_partial_eq_impl!(bool);
+
+crate::subset_of_intersection_identity_impl!(bool);
+
 #[cfg(test)]
 mod tests {
     use rstest::*;

--- a/src/impls/box.rs
+++ b/src/impls/box.rs
@@ -3,6 +3,7 @@ use crate::operations::{
     Difference, DifferenceAssign, DisjunctiveUnion, DisjunctiveUnionAssign, Intersection,
     IntersectionAssign, Union, UnionAssign,
 };
+use crate::comparisons::{SetEq, SubsetOf};
 
 impl<Value: Set> Set for Box<Value> {
     type Empty = Box<Value::Empty>;
@@ -94,5 +95,23 @@ where
 
     fn disjunctive_union(self, rhs: OtherValue) -> Self::Output {
         Box::new((*self).disjunctive_union(rhs))
+    }
+}
+
+impl<Value, OtherValue> SetEq<OtherValue> for Box<Value>
+where
+    Value: SetEq<OtherValue>,
+{
+    fn set_eq(&self, rhs: &OtherValue) -> bool {
+        Value::set_eq(&**self, rhs)
+    }
+}
+
+impl<Value, OtherValue> SubsetOf<OtherValue> for Box<Value>
+where
+    Value: SubsetOf<OtherValue>,
+{
+    fn subset_of(&self, rhs: &OtherValue) -> bool {
+        Value::subset_of(&**self, rhs)
     }
 }

--- a/src/impls/btreemap.rs
+++ b/src/impls/btreemap.rs
@@ -10,8 +10,8 @@ impl_map_ref_operations!(BTreeMap, BTreeMap, Key: Ord + Eq + Clone);
 impl_map_ref_operations!(BTreeMap, HashMap, Key: Hash + Ord + Eq + Clone);
 impl_map_owned_operations!(BTreeMap, BTreeMap, Key: Ord + Eq);
 impl_map_owned_operations!(BTreeMap, HashMap, Key: Hash + Ord + Eq);
-impl_map_comparisons!(BTreeMap, BTreeMap, Key: Ord + Eq + Clone);
-impl_map_comparisons!(BTreeMap, HashMap, Key: Hash + Ord + Eq + Clone);
+impl_map_comparisons!(BTreeMap, BTreeMap, Key: Ord + Eq);
+impl_map_comparisons!(BTreeMap, HashMap, Key: Hash + Ord + Eq);
 
 #[cfg(feature = "phf")]
 mod phf_impl {

--- a/src/impls/btreemap.rs
+++ b/src/impls/btreemap.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::hash::Hash;
 
-use crate::{Set, impl_map_owned_operations, impl_map_ref_operations};
+use crate::{Set, impl_map_owned_operations, impl_map_ref_operations, impl_map_comparisons};
 
 use crate::impl_map;
 
@@ -10,6 +10,8 @@ impl_map_ref_operations!(BTreeMap, BTreeMap, Key: Ord + Eq + Clone);
 impl_map_ref_operations!(BTreeMap, HashMap, Key: Hash + Ord + Eq + Clone);
 impl_map_owned_operations!(BTreeMap, BTreeMap, Key: Ord + Eq);
 impl_map_owned_operations!(BTreeMap, HashMap, Key: Hash + Ord + Eq);
+impl_map_comparisons!(BTreeMap, BTreeMap, Key: Ord + Eq + Clone);
+impl_map_comparisons!(BTreeMap, HashMap, Key: Hash + Ord + Eq + Clone);
 
 #[cfg(feature = "phf")]
 mod phf_impl {
@@ -18,6 +20,8 @@ mod phf_impl {
     use phf_shared::PhfBorrow;
     impl_map_ref_operations!(BTreeMap, PhfMap, Key: (Ord + PhfHash + PhfBorrow<Key> + Eq + Clone), entries);
     impl_map_ref_operations!(BTreeMap, PhfOrderedMap, Key: (Ord + PhfHash + PhfBorrow<Key> + Eq + Clone), entries);
+    impl_map_comparisons!(BTreeMap, PhfMap, Key: (Ord + PhfHash + PhfBorrow<Key> + Eq + Clone));
+    impl_map_comparisons!(BTreeMap, PhfOrderedMap, Key: (Ord + PhfHash + PhfBorrow<Key> + Eq + Clone));
 }
 
 #[cfg(test)]

--- a/src/impls/hashmap.rs
+++ b/src/impls/hashmap.rs
@@ -1,13 +1,17 @@
 use std::collections::{BTreeMap, HashMap};
 pub use std::hash::Hash;
 
-use crate::{Set, impl_map, impl_map_owned_operations, impl_map_ref_operations};
+use crate::{
+    Set, impl_map, impl_map_owned_operations, impl_map_ref_operations, impl_map_comparisons,
+};
 
 impl_map!(HashMap, Key: Hash + Eq);
 impl_map_ref_operations!(HashMap, HashMap, Key: Hash + Eq + Clone);
 impl_map_ref_operations!(HashMap, BTreeMap, Key: Hash + Ord + Eq + Clone);
 impl_map_owned_operations!(HashMap, HashMap, Key: Hash + Eq);
 impl_map_owned_operations!(HashMap, BTreeMap, Key: Hash + Ord + Eq);
+impl_map_comparisons!(HashMap, HashMap, Key: Hash + Eq + Clone);
+impl_map_comparisons!(HashMap, BTreeMap, Key: Hash + Ord + Eq + Clone);
 
 #[cfg(feature = "phf")]
 mod phf_impl {
@@ -16,6 +20,8 @@ mod phf_impl {
     use phf_shared::PhfBorrow;
     impl_map_ref_operations!(HashMap, PhfMap, Key: (Hash + PhfHash + PhfBorrow<Key> + Eq + Clone), entries);
     impl_map_ref_operations!(HashMap, PhfOrderedMap, Key: (Hash + PhfHash + PhfBorrow<Key> + Eq + Clone), entries);
+    impl_map_comparisons!(HashMap, PhfMap, Key: (Hash + PhfHash + PhfBorrow<Key> + Eq + Clone));
+    impl_map_comparisons!(HashMap, PhfOrderedMap, Key: (Hash + PhfHash + PhfBorrow<Key> + Eq + Clone));
 }
 
 #[cfg(test)]

--- a/src/impls/hashmap.rs
+++ b/src/impls/hashmap.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 pub use std::hash::Hash;
 
 use crate::{
-    Set, impl_map, impl_map_owned_operations, impl_map_ref_operations, impl_map_comparisons,
+    Set, impl_map, impl_map_comparisons, impl_map_owned_operations, impl_map_ref_operations,
 };
 
 impl_map!(HashMap, Key: Hash + Eq);
@@ -10,8 +10,8 @@ impl_map_ref_operations!(HashMap, HashMap, Key: Hash + Eq + Clone);
 impl_map_ref_operations!(HashMap, BTreeMap, Key: Hash + Ord + Eq + Clone);
 impl_map_owned_operations!(HashMap, HashMap, Key: Hash + Eq);
 impl_map_owned_operations!(HashMap, BTreeMap, Key: Hash + Ord + Eq);
-impl_map_comparisons!(HashMap, HashMap, Key: Hash + Eq + Clone);
-impl_map_comparisons!(HashMap, BTreeMap, Key: Hash + Ord + Eq + Clone);
+impl_map_comparisons!(HashMap, HashMap, Key: Hash + Eq);
+impl_map_comparisons!(HashMap, BTreeMap, Key: Hash + Ord + Eq);
 
 #[cfg(feature = "phf")]
 mod phf_impl {

--- a/src/impls/map.rs
+++ b/src/impls/map.rs
@@ -307,7 +307,6 @@ macro_rules! impl_map_ref_operations {
     };
 }
 
-
 #[macro_export]
 macro_rules! impl_map_comparisons {
     ($map:ident, $rhs_map:ident, Key: ($($bounds:tt)*)) => {
@@ -318,8 +317,7 @@ macro_rules! impl_map_comparisons {
             $crate::comparisons::SetEq<$rhs_map<Key, OtherValue>> for $map<Key, Value>
         where
             Key: $($bounds)*,
-            Value: $crate::comparisons::SetEq<OtherValue> + Clone,
-            OtherValue: Clone + Set + Into<Value>
+            Value: $crate::comparisons::SetEq<OtherValue>,
         {
             fn set_eq(&self, rhs: &$rhs_map<Key, OtherValue>) -> bool {
                 rhs.$rhs_key_func().all(|k| self.get(k).is_some()) &&
@@ -332,8 +330,7 @@ macro_rules! impl_map_comparisons {
             $crate::comparisons::SubsetOf<$rhs_map<Key, OtherValue>> for $map<Key, Value>
         where
             Key: $($bounds)*,
-            Value: $crate::comparisons::SubsetOf<OtherValue> + Clone,
-            OtherValue: Clone + Set + Into<Value>
+            Value: $crate::comparisons::SubsetOf<OtherValue>,
         {
             fn subset_of(&self, rhs: &$rhs_map<Key, OtherValue>) -> bool {
                 self.$self_iter_func()

--- a/src/impls/map.rs
+++ b/src/impls/map.rs
@@ -306,3 +306,42 @@ macro_rules! impl_map_ref_operations {
       impl_map_ref_operations!($map, $rhs_map, Key: ($($bounds)*));
     };
 }
+
+
+#[macro_export]
+macro_rules! impl_map_comparisons {
+    ($map:ident, $rhs_map:ident, Key: ($($bounds:tt)*)) => {
+      impl_map_comparisons!($map, $rhs_map, Key: ($($bounds)*), iter, keys);
+    };
+    ($map:ident, $rhs_map:ident, Key: ($($bounds:tt)*), $self_iter_func:ident, $rhs_key_func:ident) => {
+        impl<Key, Value, OtherValue>
+            $crate::comparisons::SetEq<$rhs_map<Key, OtherValue>> for $map<Key, Value>
+        where
+            Key: $($bounds)*,
+            Value: $crate::comparisons::SetEq<OtherValue> + Clone,
+            OtherValue: Clone + Set + Into<Value>
+        {
+            fn set_eq(&self, rhs: &$rhs_map<Key, OtherValue>) -> bool {
+                rhs.$rhs_key_func().all(|k| self.get(k).is_some()) &&
+                self.$self_iter_func()
+                    .all(|(k, v)| rhs.get(k).is_some_and(|rhs_v| v.set_eq(rhs_v)))
+            }
+        }
+
+        impl<Key, Value, OtherValue>
+            $crate::comparisons::SubsetOf<$rhs_map<Key, OtherValue>> for $map<Key, Value>
+        where
+            Key: $($bounds)*,
+            Value: $crate::comparisons::SubsetOf<OtherValue> + Clone,
+            OtherValue: Clone + Set + Into<Value>
+        {
+            fn subset_of(&self, rhs: &$rhs_map<Key, OtherValue>) -> bool {
+                self.$self_iter_func()
+                    .all(|(k, v)| rhs.get(k).is_some_and(|rhs_v| v.subset_of(rhs_v)))
+            }
+        }
+    };
+    ($map:ident, $rhs_map:ident, Key: $($bounds:tt)*) => {
+      impl_map_comparisons!($map, $rhs_map, Key: ($($bounds)*));
+    };
+}

--- a/src/impls/option.rs
+++ b/src/impls/option.rs
@@ -2,6 +2,7 @@ use crate::Set;
 use crate::operations::{
     DifferenceAssign, DisjunctiveUnionAssign, Intersection, IntersectionAssign, UnionAssign,
 };
+use crate::comparisons::{SetEq, SubsetOf};
 
 impl<Value: Set> Set for Option<Value> {
     type Empty = Self;
@@ -126,6 +127,33 @@ where
         }
     }
 }
+
+impl<Value, OtherValue: Set> SetEq<OtherValue> for Option<Value>
+where
+    Value: SetEq<OtherValue>,
+{
+    fn set_eq(&self, rhs: &OtherValue) -> bool {
+        match self {
+            Some(v) if v.set_eq(rhs) => true,
+            None if rhs.is_empty() => true,
+            _ => false,
+        }
+    }
+}
+
+impl<Value, OtherValue: Set> SubsetOf<OtherValue> for Option<Value>
+where
+    Value: SubsetOf<OtherValue>,
+{
+    fn subset_of(&self, rhs: &OtherValue) -> bool {
+        match self {
+            Some(v) if v.subset_of(rhs) => true,
+            None if rhs.is_empty() => true,
+            _ => false,
+        }
+    }
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/src/impls/tuples.rs
+++ b/src/impls/tuples.rs
@@ -84,16 +84,16 @@ macro_rules! impl_op_assign_ref_tuple {
     };
 }
 
-macro_rules! impl_subset_of_tuple {
-    ($(($ty:ident, $rest_ty:ident)),+) => {
-        impl<$($ty: $crate::comparisons::SubsetOf<$rest_ty>, $rest_ty),*> $crate::comparisons::SubsetOf<($($rest_ty,)*)> for ($($ty,)*) {
-            fn subset_of(&self, other: &($($rest_ty,)*)) -> bool {
+macro_rules! impl_comparison_tuple {
+    ($op:ident, $func_name:ident, $(($ty:ident, $rest_ty:ident)),+) => {
+        impl<$($ty: $crate::comparisons::$op<$rest_ty>, $rest_ty),*> $crate::comparisons::$op<($($rest_ty,)*)> for ($($ty,)*) {
+            fn $func_name(&self, other: &($($rest_ty,)*)) -> bool {
                 #[allow(non_snake_case)]
                 let ($($ty,)+) = self;
                 #[allow(non_snake_case)]
                 let ($($rest_ty,)+) = other;
 
-                $($ty.subset_of($rest_ty))&&*
+                $($ty.$func_name($rest_ty))&&*
             }
         }
     };
@@ -118,7 +118,8 @@ macro_rules! impl_tuples {
         impl_op_assign_ref_tuple!(DifferenceAssign, difference_assign, ($first, $first_rest) $(, ($rest, $rest_rest))*);
         impl_op_ref_tuple!(DisjunctiveUnion, disjunctive_union, ($first, $first_rest) $(, ($rest, $rest_rest))*);
         impl_op_assign_ref_tuple!(DisjunctiveUnionAssign, disjunctive_union_assign, ($first, $first_rest) $(, ($rest, $rest_rest))*);
-        impl_subset_of_tuple!(($first, $first_rest) $(, ($rest, $rest_rest))*);
+        impl_comparison_tuple!(SetEq, set_eq, ($first, $first_rest) $(, ($rest, $rest_rest))*);
+        impl_comparison_tuple!(SubsetOf, subset_of, ($first, $first_rest) $(, ($rest, $rest_rest))*);
         impl_tuples!($(($rest, $rest_rest)),*);
     };
     () => {};


### PR DESCRIPTION
This removes a blanket implementation based on intersection in favor of specific ones. Added derive macros.